### PR TITLE
Use `bunt` shorthand for coloring `{}` placeholder

### DIFF
--- a/src/bencher.rs
+++ b/src/bencher.rs
@@ -88,8 +88,8 @@ impl Bencher {
 
     fn default_format(stats: &Stats, bencher: &Bencher) {
         bunt::println!(
-            "{$bg:white+blue+bold}{}{/$} ... {$green}{}{/$} ns/iter (+/- {$red}{}{/$}) = {$#FFA500}{:.2}{/$} MB/s\
-            \n\t memory usage: {$green}{}{/$} bytes/iter (+/- {$red}{}{/$})\
+            "{[bg:white+blue+bold]} ... {[green]} ns/iter (+/- {[red]}) = {[#FFA500]:.2} MB/s\
+            \n\t memory usage: {[green]} bytes/iter (+/- {[red]})\
             \n\t {$bold}{}@Total: {} * {} iters{/$}",
              &bencher.name,
              fmt_thousands_sep(stats.times_average, ','),


### PR DESCRIPTION
I saw that your project uses `bunt`. I quickly checked the code and saw that you can use a shorthand syntax in a lot of places. `{$style}{}{/$}` is equivalent to `{[style]}`. I guess this is a bit easier to read :)

Also, just a related hint: using hex code colors (i.e. non predefined ones) is always a bit tricky when people use a different color scheme in their terminal. It might look good on your terminal, but not necessarily on other color schemes. Therefore it is recommended to sticking with the predefined colors whenever possible. 